### PR TITLE
Update rtos-source-for-build.md

### DIFF
--- a/docs/building/rtos-source-for-build.md
+++ b/docs/building/rtos-source-for-build.md
@@ -9,7 +9,7 @@ This document aims to give you an brief overview of the differences between thes
 
 ### Source from official repository
 
-When running CMake, if the parameter `-DCHIBIOS_SOURCE` is not not specified CMake will connect to **nanoFramework**s [ChibiOS mirror](https://github.com/nanoframework/ChibiOS) on GitHub and will clone the source from there. The time for this operation to complete will mostly depend on the speed of your internet connection. Note that you have the option to specify the `-CHIBIOS_VERSION` (e.g. `17.6.2`) if you would like to target a specific release else the latest code from the 'stable_17.6.x' branch will be checked out instead.
+When running CMake, if the parameter `-DCHIBIOS_SOURCE` is not not specified CMake will connect to **nanoFrameworks** [ChibiOS mirror](https://github.com/nanoframework/ChibiOS) on GitHub and will clone the source from there. The time for this operation to complete will mostly depend on the speed of your internet connection. Note that you have the option to specify the `-CHIBIOS_VERSION` (e.g. `17.6.2`) if you would like to target a specific release else the latest code from the 'stable_17.6.x' branch will be checked out instead.
 
 ChibiOS will be cached within the build directory so the full download won't happen again unless the build directory is cleared. A check for any changes in the repo is made whenever a build is run. If there are any, the changes will be downloaded and merged.
 

--- a/docs/building/rtos-source-for-build.md
+++ b/docs/building/rtos-source-for-build.md
@@ -31,6 +31,6 @@ This option is good when you have a local clone of the repo and you don't want t
 
 The downside is that you have to manage the update process for the ChibiOs repo yourself.
 
-Another important aspect to consider is the branch **to _manually_ checkout**. Not doing this is synonym of using the 'master' branch that contains the development files and not a stable version, which is probably what you want to use.
+Another important aspect to consider is the branch **to _manually_ checkout**. Not doing this is synonym of using the 'master' branch that contains the development files and is not a stable version, which is probably not what you want to use.
 
 Also here, if the build folder is cleaned the 'cached' repo will be gone.

--- a/docs/building/rtos-source-for-build.md
+++ b/docs/building/rtos-source-for-build.md
@@ -1,4 +1,3 @@
-
 ## Building **nanoFramework** with local RTOS source vs RTOS source from repository
 
 
@@ -10,29 +9,28 @@ This document aims to give you an brief overview of the differences between thes
 
 ### Source from official repository
 
-When running CMake if the parameter `-DCHIBIOS_SOURCE` is not not specified what happens is that Cake will connect to [ChibiOS repo](https://github.com/nanoframework/ChibiOS) on GitHub and will download it from there. The time for this operation to complete will depend mostly on the speed of the Internet connection. Note that you can specify `-CHIBIOS_VERSION` too otherwise the latest code from the 'stable_17.6.x' branch will be checked out instead.
+When running CMake, if the parameter `-DCHIBIOS_SOURCE` is not not specified CMake will connect to **nanoFramework**s [ChibiOS mirror](https://github.com/nanoframework/ChibiOS) on GitHub and will clone the source from there. The time for this operation to complete will mostly depend on the speed of your internet connection. Note that you have the option to specify the `-CHIBIOS_VERSION` (e.g. `17.6.2`) if you would like to target a specific release else the latest code from the 'stable_17.6.x' branch will be checked out instead.
 
-ChibiOS will be cached in the build directory so the full download won't happen again unless the build directory is cleared. A check for any changes in the repo is made whenever a build is run. If there are any, the changes will be downloaded and merged.
+ChibiOS will be cached within the build directory so the full download won't happen again unless the build directory is cleared. A check for any changes in the repo is made whenever a build is run. If there are any, the changes will be downloaded and merged.
 
-This option is good for automated builds or when you don't have (or don't want) the repo cloned to your local disk.
+This option is good for automated builds or when you don't have (or don't want) the repo cloned to your local storage device.
 
-Another advantage is that you don't have to manage the updates on the local clone.
+Another advantage is that you don't have to manage the updates to the local clone yourself.
 
-An obvious disadvantage is that if the build folder is cleaned the 'cached' repo will be gone.
+An obvious disadvantage is that if the build folder is cleaned (required when switching between target boards) the 'cached' repo will be gone and a full download will occur when the project is next built.
 
 
 
 
 ### Source from local clone
 
-When running CMake, if the parameter `-DCHIBIOS_SOURCE="....."` is specified a local clone located at the designated path will be used in the build. When using this option the `-CHIBIOS_VERSION` is not taken into account.
-The only time penalty is the one necessary for CMake to copy the contents of the repo to the build cache folder. This is a one time operation and it won't happen again unless the build folder is cleaned up.
+When running CMake, if the parameter `-DCHIBIOS_SOURCE="....."` is specified a local clone located at the designated path will be used when the build occurs. When using this option the `-CHIBIOS_VERSION` is not taken into account.
+The only time penalty is the one necessary for CMake to copy the contents of the local ChibiOs repo to the build cache folder. This is a one time operation and it won't happen again unless the build folder is cleaned up.
 
-This option is good when you have a local clone of the repo and you don't want to increase the build time with checks on the repo and downloading it.
+This option is good when you have a local clone of the repo and you don't want to increase the build time with checks on the repo and downloading it or wish to target a different branch (such as `master`).
 
-The downside is that you have to manage the updates from the repo yourself.
+The downside is that you have to manage the update process for the ChibiOs repo yourself.
 
-Another important aspect to consider is that you **have to _manually_ checkout** the branch that you want to use in the build. This is because CMake can't checkout branches for you.
-Not doing this is synonym of using the 'master' branch that contains the development files and not a stable version, which is probably what you want to use.
+Another important aspect to consider is the branch **to _manually_ checkout**. Not doing this is synonym of using the 'master' branch that contains the development files and not a stable version, which is probably what you want to use.
 
 Also here, if the build folder is cleaned the 'cached' repo will be gone.


### PR DESCRIPTION
Updates to grammer

Fix concerning the way ChibiOs is downloaded using cmake (now targets 17.6.x stable branch)