### PR TITLE
Remove Documentation Reference to ST Cube Repository

### DIFF
--- a/docs/building/README.md
+++ b/docs/building/README.md
@@ -9,7 +9,6 @@
 
 * ### [CMake](cmake)
   * [Building with ChibiOS](cmake/chibios-build.md)
-  * [ST Cube repository](cmake/stcube-repository.md)
   * [_Toolchain file_ for STM32 with GNU ARM Embedded](cmake/stm32-gcc-toolchain.md)
   * [_Toolchain file_ for ChibiOS GNU ARM Embedded](cmake/chibios-toolchain.md)
   * [Building using Ninja](cmake/ninja-build.md)


### PR DESCRIPTION
Remove Reference to ST Cube Repository

As it currently links to a missing file which appears to be removed due to issue #33  

Signed-off-by: Ryan Griffin