### PR TITLE
Fixed typo in URL pointing to documentation page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ See some of our guides for more details:
 
 ## Documentation
 
-### [Docs](https://docs.nanoframework.net/content/index.html)
+### [Docs](https://docs.nanoframework.net)
 
 The project documentation is a great place to find information about **nanoFramework**, no matter if you are newcomer or a veteran. It's organized in the following categories:
 


### PR DESCRIPTION
Fixed broken link to documentation page. Minor, but arguably high-visibility (since it's probably one of the first links a prospective new user is likely to click)